### PR TITLE
Refactor experience & education tiles to use a shared RecordTile component

### DIFF
--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,10 +1,34 @@
+import Link from 'next/link';
+
+import { RecordTile, RecordTileProps } from '@/components/Tiles/RecordTile';
 import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
-import LinkWithArrow from '@/components/ui/LinkWithArrow';
-import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { cn } from '@/lib/utils';
 
 export function Education() {
-  const isTablet = useMediaQuery('(min-width: 768px)');
+  const educationDetails = (
+    <p className="mt-1 py-0 text-gray-700 dark:text-gray-300">
+      <Link
+        href="https://uwaterloo.ca/computational-mathematics/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mr-0.5 hover:text-black hover:underline hover:underline-offset-4 dark:hover:text-white"
+      >
+        Computational Mathematics
+      </Link>{' '}
+      is a interdisplinary major that combines Mathematics, Statistics, Optimization and Computer
+      Science, offered by the Faculty of Mathematics.
+      {/* TODO: Insert all courses using a recursive React component */}
+    </p>
+  );
+  const uwrecord: RecordTileProps = {
+    organizationLogo: '/images/uwaterlooLogo.png',
+    organizationName: 'University of Waterloo',
+    organizationLink: 'https://uwaterloo.ca/',
+    role: 'Bachelor of Mathematics, Computational Mathematics Major',
+    duration: 'Sept 2022 - Present',
+    details: educationDetails,
+    organizationBeforeRole: true,
+  };
   return (
     <section id="education" className="mb-12">
       <BlurFade delay={BLUR_FADE_DELAY * 7}>
@@ -18,62 +42,7 @@ export function Education() {
         </h2>
       </BlurFade>
       <BlurFade delay={BLUR_FADE_DELAY * 8}>
-        <div className="flex items-center">
-          <div className="relative flex-grow md:pl-12">
-            <div className={'absolute left-[5px] aspect-square rounded-lg bg-white'}>
-              {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
-              <img
-                src="/images/uwaterlooLogo.png"
-                alt={'University of Waterloo logo'}
-                width={isTablet ? 80 : 45}
-                height={isTablet ? 80 : 45}
-                className="rounded-md"
-              />
-            </div>
-            <div className={'pl-16 ' + (isTablet && 'py-3')}>
-              <div className="mb-2 flex flex-col justify-between sm:flex-row md:items-start">
-                <div>
-                  <LinkWithArrow
-                    href="https://uwaterloo.ca/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={'Link to University of Waterloo'}
-                  >
-                    <h2 className="inline-flex items-center text-xl font-bold">
-                      University of Waterloo
-                    </h2>
-                  </LinkWithArrow>
-                  <h3 className="text-lg font-semibold">
-                    Bachelor of Mathematics, Computational Mathematics Major
-                  </h3>
-                  {!isTablet && (
-                    <h3 className="font-typewriter text-gray-600 dark:text-gray-400">
-                      Sept 2022 - Present
-                    </h3>
-                  )}
-                </div>
-                {isTablet && (
-                  <h3 className="font-typewriter text-gray-600 dark:text-gray-400">
-                    Sept 2022 - Present
-                  </h3>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-        <p className="mt-1 py-0 text-gray-700 dark:text-gray-300">
-          <LinkWithArrow
-            href="https://uwaterloo.ca/computational-mathematics/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mr-0.5"
-          >
-            Computational Mathematics
-          </LinkWithArrow>{' '}
-          is a interdisplinary major that combines Mathematics, Statistics, Optimization and
-          Computer Science, offered by the Faculty of Mathematics.
-          {/* TODO: Insert all courses using a recursive React component */}
-        </p>
+        <RecordTile {...uwrecord} />
       </BlurFade>
     </section>
   );

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { RecordTile, RecordTileProps } from '@/components/Tiles/RecordTile';
+import { EducationTile } from '@/components/Tiles/EducationTile';
 import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
 import { cn } from '@/lib/utils';
 
@@ -20,15 +20,7 @@ export function Education() {
       {/* TODO: Insert all courses using a recursive React component */}
     </p>
   );
-  const uwrecord: RecordTileProps = {
-    organizationLogo: '/images/uwaterlooLogo.png',
-    organizationName: 'University of Waterloo',
-    organizationLink: 'https://uwaterloo.ca/',
-    role: 'Bachelor of Mathematics, Computational Mathematics Major',
-    duration: 'Sept 2022 - Present',
-    details: educationDetails,
-    organizationBeforeRole: true,
-  };
+
   return (
     <section id="education" className="mb-12">
       <BlurFade delay={BLUR_FADE_DELAY * 7}>
@@ -42,7 +34,15 @@ export function Education() {
         </h2>
       </BlurFade>
       <BlurFade delay={BLUR_FADE_DELAY * 8}>
-        <RecordTile {...uwrecord} />
+        <EducationTile
+          institutionLogo={'/images/uwaterlooLogo.png'}
+          institutionName={'University of Waterloo'}
+          institutionLink={'https://uwaterloo.ca/'}
+          degree={'Bachelor of Mathematics'}
+          major={'Computational Mathematics Major'}
+          duration={'Sept 2022 - Present'}
+          details={educationDetails}
+        />
       </BlurFade>
     </section>
   );

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -4,7 +4,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { cn } from '@/lib/utils';
 
 export function Education() {
-  const isDesktop = useMediaQuery('(min-width: 768px)');
+  const isTablet = useMediaQuery('(min-width: 768px)');
   return (
     <section id="education" className="mb-12">
       <BlurFade delay={BLUR_FADE_DELAY * 7}>
@@ -25,12 +25,12 @@ export function Education() {
               <img
                 src="/images/uwaterlooLogo.png"
                 alt={'University of Waterloo logo'}
-                width={isDesktop ? 80 : 45}
-                height={isDesktop ? 80 : 45}
+                width={isTablet ? 80 : 45}
+                height={isTablet ? 80 : 45}
                 className="rounded-md"
               />
             </div>
-            <div className={'pl-16 ' + (isDesktop && 'py-3')}>
+            <div className={'pl-16 ' + (isTablet && 'py-3')}>
               <div className="mb-2 flex flex-col justify-between sm:flex-row md:items-start">
                 <div>
                   <LinkWithArrow
@@ -46,13 +46,13 @@ export function Education() {
                   <h3 className="text-lg font-semibold">
                     Bachelor of Mathematics, Computational Mathematics Major
                   </h3>
-                  {!isDesktop && (
+                  {!isTablet && (
                     <h3 className="font-typewriter text-gray-600 dark:text-gray-400">
                       Sept 2022 - Present
                     </h3>
                   )}
                 </div>
-                {isDesktop && (
+                {isTablet && (
                   <h3 className="font-typewriter text-gray-600 dark:text-gray-400">
                     Sept 2022 - Present
                   </h3>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ const Header = ({
   email,
   resumeFile,
 }: HeaderProps) => {
-  const isDesktop = useMediaQuery('(min-width: 768px)');
+  const isTablet = useMediaQuery('(min-width: 768px)');
   const [copied, setCopiedId] = useState<string>();
   useEffect(() => {
     setTimeout(() => {
@@ -44,7 +44,7 @@ const Header = ({
     <div className="container mx-auto mb-10">
       <div className="flex flex-col items-center justify-between md:flex-row">
         <BlurFade delay={BLUR_FADE_DELAY}>
-          {!isDesktop && (
+          {!isTablet && (
             <div className="mb-4 flex-shrink-0 md:mb-0 md:mr-8">
               <img
                 src="/images/headshot.jpg"
@@ -145,7 +145,7 @@ const Header = ({
           </div>
         </div>
         <BlurFade delay={BLUR_FADE_DELAY} inView={true}>
-          {isDesktop && (
+          {isTablet && (
             <div className="flex-shrink-0">
               <img
                 src="/images/headshot.jpg"

--- a/src/components/Tiles/EducationTile.tsx
+++ b/src/components/Tiles/EducationTile.tsx
@@ -1,0 +1,34 @@
+import { RecordTile } from '@/components/Tiles/RecordTile';
+
+export type EducationTileProps = {
+  institutionLogo: string;
+  institutionName: string;
+  institutionLink: string;
+  degree: string;
+  major: string;
+  duration: string;
+  details?: React.ReactNode;
+};
+
+export function EducationTile({
+  institutionLogo,
+  institutionName,
+  institutionLink,
+  degree,
+  major,
+  duration,
+  details,
+}: EducationTileProps) {
+  const combinedDegreeNameAndMajor = degree.concat(', ').concat(major);
+  return (
+    <RecordTile
+      organizationLogo={institutionLogo}
+      organizationName={institutionName}
+      organizationLink={institutionLink}
+      role={combinedDegreeNameAndMajor}
+      duration={duration}
+      body={details}
+      organizationBeforeRole={true}
+    />
+  );
+}

--- a/src/components/Tiles/ExperienceTile.tsx
+++ b/src/components/Tiles/ExperienceTile.tsx
@@ -28,18 +28,22 @@ export function ExperienceTile({
         'flex items-center'
       }
     >
-      <div className="relative flex-grow md:pl-12">
-        <div className="absolute left-[5px] top-3 aspect-square rounded-lg bg-white">
-          {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
-          <img
-            src={companyLogo}
-            alt={`${companyName} logo`}
-            width={isDesktop ? 80 : 45}
-            height={isDesktop ? 80 : 45}
-            className="rounded-md"
-          />
-        </div>
-        <div className="py-3 pl-16">
+      <div className="group relative flex-grow lg:-ml-[132px] xl:-ml-40 2xl:-ml-52">
+        {isDesktop && (
+          <div className="opacity-0 transition-opacity delay-100 md:group-hover:opacity-100">
+            <div className="absolute top-1/2 aspect-square -translate-y-1/2 transform rounded-lg bg-white">
+              {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
+              <img
+                src={companyLogo}
+                alt={`${companyName} logo`}
+                width={80}
+                height={80}
+                className="rounded-md"
+              />
+            </div>
+          </div>
+        )}
+        <div className="py-3 lg:pl-[132px] xl:pl-40 2xl:pl-52">
           <div className="mb-4 flex flex-col justify-between sm:flex-row md:items-start">
             <div>
               <h2 className="text-xl font-bold">{position}</h2>

--- a/src/components/Tiles/ExperienceTile.tsx
+++ b/src/components/Tiles/ExperienceTile.tsx
@@ -20,6 +20,7 @@ export function ExperienceTile({
   responsibilities,
 }: ExperienceTileProps) {
   const isTablet = useMediaQuery('(min-width: 768px)');
+  const isDesktop = useMediaQuery('(min-width: 1280px)');
   return (
     <div
       className={
@@ -31,13 +32,13 @@ export function ExperienceTile({
       <div className="group relative flex-grow lg:-ml-[132px] xl:-ml-40 2xl:-ml-52">
         {isTablet && (
           <div className="opacity-0 transition-opacity delay-100 md:group-hover:opacity-100">
-            <div className="absolute top-1/2 aspect-square -translate-y-1/2 transform rounded-lg bg-white">
+            <div className="absolute top-1/2 aspect-square -translate-y-1/2 transform rounded-lg bg-transparent">
               {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
               <img
                 src={companyLogo}
                 alt={`${companyName} logo`}
-                width={80}
-                height={80}
+                width={isDesktop ? 80 : 70}
+                height={isDesktop ? 80 : 70}
                 className="rounded-md"
               />
             </div>

--- a/src/components/Tiles/ExperienceTile.tsx
+++ b/src/components/Tiles/ExperienceTile.tsx
@@ -19,17 +19,17 @@ export function ExperienceTile({
   period,
   responsibilities,
 }: ExperienceTileProps) {
-  const isDesktop = useMediaQuery('(min-width: 768px)');
+  const isTablet = useMediaQuery('(min-width: 768px)');
   return (
     <div
       className={
-        (!(responsibilities && responsibilities.length > 0) && !isDesktop ? '-mb-6' : 'mb-6') +
+        (!(responsibilities && responsibilities.length > 0) && !isTablet ? '-mb-6' : 'mb-6') +
         ' ' +
         'flex items-center'
       }
     >
       <div className="group relative flex-grow lg:-ml-[132px] xl:-ml-40 2xl:-ml-52">
-        {isDesktop && (
+        {isTablet && (
           <div className="opacity-0 transition-opacity delay-100 md:group-hover:opacity-100">
             <div className="absolute top-1/2 aspect-square -translate-y-1/2 transform rounded-lg bg-white">
               {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
@@ -55,11 +55,11 @@ export function ExperienceTile({
               >
                 <h3 className="text-lg font-semibold">{companyName}</h3>
               </LinkWithArrow>
-              {!isDesktop && (
+              {!isTablet && (
                 <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{period}</h3>
               )}
             </div>
-            {isDesktop && (
+            {isTablet && (
               <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{period}</h3>
             )}
           </div>

--- a/src/components/Tiles/ExperienceTile.tsx
+++ b/src/components/Tiles/ExperienceTile.tsx
@@ -22,13 +22,7 @@ export function ExperienceTile({
   const isTablet = useMediaQuery('(min-width: 768px)');
   const isDesktop = useMediaQuery('(min-width: 1280px)');
   return (
-    <div
-      className={
-        (!(responsibilities && responsibilities.length > 0) && !isTablet ? '-mb-6' : 'mb-6') +
-        ' ' +
-        'flex items-center'
-      }
-    >
+    <div className="-mb-2 flex items-center">
       <div className="group relative flex-grow lg:-ml-[132px] xl:-ml-40 2xl:-ml-52">
         {isTablet && (
           <div className="opacity-0 transition-opacity delay-100 md:group-hover:opacity-100">
@@ -45,7 +39,7 @@ export function ExperienceTile({
           </div>
         )}
         <div className="py-3 lg:pl-[132px] xl:pl-40 2xl:pl-52">
-          <div className="mb-4 flex flex-col justify-between sm:flex-row md:items-start">
+          <div className="flex flex-col justify-between sm:flex-row md:items-start">
             <div>
               <h2 className="text-xl font-bold">{position}</h2>
               <LinkWithArrow
@@ -65,7 +59,7 @@ export function ExperienceTile({
             )}
           </div>
           {responsibilities && responsibilities.length > 0 && (
-            <div className="mt-4">
+            <div className="mt-3">
               <ul className="list-inside list-['-_'] space-y-1 text-gray-700 dark:text-gray-300">
                 {responsibilities.map((responsibility, index) => (
                   <li key={index}>{responsibility}</li>

--- a/src/components/Tiles/ExperienceTile.tsx
+++ b/src/components/Tiles/ExperienceTile.tsx
@@ -61,9 +61,9 @@ export function ExperienceTile({
           </div>
           {responsibilities && responsibilities.length > 0 && (
             <div className="mt-4">
-              <ul className="list-inside space-y-1 text-gray-700 dark:text-gray-300">
+              <ul className="list-inside list-['-_'] space-y-1 text-gray-700 dark:text-gray-300">
                 {responsibilities.map((responsibility, index) => (
-                  <li key={index}>- {responsibility}</li>
+                  <li key={index}>{responsibility}</li>
                 ))}
               </ul>
             </div>

--- a/src/components/Tiles/ExperienceTile.tsx
+++ b/src/components/Tiles/ExperienceTile.tsx
@@ -1,6 +1,6 @@
-import LinkWithArrow from '@/components/ui/LinkWithArrow';
-import { useMediaQuery } from '@/hooks/useMediaQuery';
-// import Image from 'next/image';
+import { Icon } from '@iconify/react';
+
+import { RecordTile } from '@/components/Tiles/RecordTile';
 
 export type ExperienceTileProps = {
   companyLogo: string;
@@ -19,56 +19,30 @@ export function ExperienceTile({
   period,
   responsibilities,
 }: ExperienceTileProps) {
-  const isTablet = useMediaQuery('(min-width: 768px)');
-  const isDesktop = useMediaQuery('(min-width: 1280px)');
-  return (
-    <div className="-mb-2 flex items-center">
-      <div className="group relative flex-grow lg:-ml-[132px] xl:-ml-40 2xl:-ml-52">
-        {isTablet && (
-          <div className="opacity-0 transition-opacity delay-100 md:group-hover:opacity-100">
-            <div className="absolute top-1/2 aspect-square -translate-y-1/2 transform rounded-lg bg-transparent">
-              {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
-              <img
-                src={companyLogo}
-                alt={`${companyName} logo`}
-                width={isDesktop ? 80 : 70}
-                height={isDesktop ? 80 : 70}
-                className="rounded-md"
-              />
-            </div>
-          </div>
-        )}
-        <div className="py-3 lg:pl-[132px] xl:pl-40 2xl:pl-52">
-          <div className="flex flex-col justify-between sm:flex-row md:items-start">
-            <div>
-              <h2 className="text-xl font-bold">{position}</h2>
-              <LinkWithArrow
-                href={companyLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`Link to ${companyName}`}
-              >
-                <h3 className="text-lg font-semibold">{companyName}</h3>
-              </LinkWithArrow>
-              {!isTablet && (
-                <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{period}</h3>
-              )}
-            </div>
-            {isTablet && (
-              <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{period}</h3>
-            )}
-          </div>
-          {responsibilities && responsibilities.length > 0 && (
-            <div className="mt-3">
-              <ul className="list-inside list-['-_'] space-y-1 text-gray-700 dark:text-gray-300">
-                {responsibilities.map((responsibility, index) => (
-                  <li key={index}>{responsibility}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-      </div>
+  const responsibilitiesAsHTML = responsibilities && responsibilities.length > 0 && (
+    <div className="mt-3">
+      <ul className="list-inside list-none space-y-1 text-gray-700 dark:text-gray-300">
+        {responsibilities.map((responsibility, index) => (
+          <li key={index}>
+            <span className="mr-1 inline-block align-middle">
+              {<Icon icon={'icons8:angle-right'} inline={true} />}
+            </span>
+            {responsibility}
+          </li>
+        ))}
+      </ul>
     </div>
+  );
+
+  return (
+    <RecordTile
+      organizationLogo={companyLogo}
+      organizationName={companyName}
+      organizationLink={companyLink}
+      role={position}
+      duration={period}
+      body={responsibilitiesAsHTML}
+      organizationBeforeRole={true}
+    />
   );
 }

--- a/src/components/Tiles/ProjectTile.tsx
+++ b/src/components/Tiles/ProjectTile.tsx
@@ -29,7 +29,7 @@ export function ProjectTile({
   liveUrl,
   techStack,
 }: ProjectTileProps) {
-  // const isDesktop = useMediaQuery('(min-width: 768px)')
+  // const isTablet = useMediaQuery('(min-width: 768px)')
   return (
     <div className="items-center">
       <div className="mb-2 flex flex-col justify-between sm:flex-row md:items-start">

--- a/src/components/Tiles/RecordTile.tsx
+++ b/src/components/Tiles/RecordTile.tsx
@@ -10,7 +10,7 @@ export type RecordTileProps = {
   organizationLink: string;
   role: string;
   duration: string;
-  details?: React.ReactNode;
+  body?: React.ReactNode;
   organizationBeforeRole?: boolean;
 };
 
@@ -82,7 +82,7 @@ export function RecordTile({
   organizationLink,
   role,
   duration,
-  details,
+  body,
   organizationBeforeRole = false,
 }: RecordTileProps) {
   const isTablet = useMediaQuery('(min-width: 768px)');
@@ -118,7 +118,7 @@ export function RecordTile({
             organizationBeforeRole,
             isTablet,
           )}
-          {details}
+          {body}
         </div>
       </div>
     </div>

--- a/src/components/Tiles/RecordTile.tsx
+++ b/src/components/Tiles/RecordTile.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import LinkWithArrow from '@/components/ui/LinkWithArrow';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+// import Image from 'next/image';
+
+export type RecordTileProps = {
+  organizationLogo: string;
+  organizationName: string;
+  organizationLink: string;
+  role: string;
+  duration: string;
+  details?: React.ReactNode;
+  organizationBeforeRole?: boolean;
+};
+
+function jobDescriptorSection(
+  organization: string,
+  link: string,
+  role: string,
+  duration: string,
+  isOrganizationBeforeRole: boolean = false,
+  isWidth768pxOrMore: boolean,
+) {
+  // styling for:
+  //    h2 - text-xl font-bold
+  //    h3 - text-lg font-semibold
+
+  const organizationNameHeadingTag = isOrganizationBeforeRole ? 'h2' : 'h3';
+  const organizationNameHeading = React.createElement(
+    LinkWithArrow,
+    {
+      href: link,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      'aria-label': `Link to ${organization}`,
+    },
+    React.createElement(
+      organizationNameHeadingTag,
+      { className: isOrganizationBeforeRole ? 'text-xl font-bold' : 'text-lg font-semibold' },
+      organization,
+    ),
+  );
+  const roleHeadingTag = !isOrganizationBeforeRole ? 'h2' : 'h3';
+  const roleHeading = React.createElement(
+    roleHeadingTag,
+    { className: !isOrganizationBeforeRole ? 'text-xl font-bold' : 'text-lg font-semibold' },
+    role,
+  );
+
+  return (
+    <div className="flex flex-col justify-between sm:flex-row md:items-start">
+      <div>
+        {isOrganizationBeforeRole ? organizationNameHeading : roleHeading}
+        {!isOrganizationBeforeRole ? organizationNameHeading : roleHeading}
+        {!isWidth768pxOrMore && (
+          <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{duration}</h3>
+        )}
+      </div>
+      {isWidth768pxOrMore && (
+        <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{duration}</h3>
+      )}
+    </div>
+  );
+}
+
+export function RecordTile({
+  organizationLogo,
+  organizationName,
+  organizationLink,
+  role,
+  duration,
+  details,
+  organizationBeforeRole = false,
+}: RecordTileProps) {
+  const isTablet = useMediaQuery('(min-width: 768px)');
+  const isDesktop = useMediaQuery('(min-width: 1280px)');
+
+  //   const topRow = (
+  //     <h2 className="text-xl font-bold">{!organizationBeforeRole ? role : organizationName}</h2>
+  //   );
+  //   const bottomRow = "";
+  return (
+    <div className="-mb-2 flex items-center">
+      <div className="group relative flex-grow lg:-ml-[132px] xl:-ml-40 2xl:-ml-52">
+        {isTablet && (
+          <div className="opacity-0 transition-opacity delay-100 md:group-hover:opacity-100">
+            <div className="absolute top-1/2 aspect-square -translate-y-1/2 transform rounded-lg bg-transparent">
+              {/* // center the bullet : `top-1/2 transform -translate-y-1/2` */}
+              <img
+                src={organizationLogo}
+                alt={`${organizationName} logo`}
+                width={isDesktop ? 80 : 70}
+                height={isDesktop ? 80 : 70}
+                className="rounded-md"
+              />
+            </div>
+          </div>
+        )}
+        <div className="py-3 lg:pl-[132px] xl:pl-40 2xl:pl-52">
+          {jobDescriptorSection(
+            organizationName,
+            organizationLink,
+            role,
+            duration,
+            organizationBeforeRole,
+            isTablet,
+          )}
+          {details}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Tiles/RecordTile.tsx
+++ b/src/components/Tiles/RecordTile.tsx
@@ -51,8 +51,20 @@ function jobDescriptorSection(
   return (
     <div className="flex flex-col justify-between sm:flex-row md:items-start">
       <div>
-        {isOrganizationBeforeRole ? organizationNameHeading : roleHeading}
-        {!isOrganizationBeforeRole ? organizationNameHeading : roleHeading}
+        <>
+          {isOrganizationBeforeRole && (
+            <>
+              {organizationNameHeading}
+              {roleHeading}
+            </>
+          )}
+          {!isOrganizationBeforeRole && (
+            <>
+              {roleHeading}
+              {organizationNameHeading}
+            </>
+          )}
+        </>
         {!isWidth768pxOrMore && (
           <h3 className="font-typewriter text-gray-600 dark:text-gray-400">{duration}</h3>
         )}


### PR DESCRIPTION
This PR introduces a unified layout component for both professional and educational experiences—making things cleaner, more reusable, and easier to maintain:

- 🧱 Introduced `RecordTile` — a generic component for rendering consistent layouts across roles and institutions.  
- 🎓 Refactored `EducationTile` to use `RecordTile`, combining degree and major into a single display string.  
- 💼 Migrated `ExperienceTile` to `RecordTile`, simplifying layout logic and improving consistency.  
- ✍️ Renamed `details` to `body` for clearer semantic meaning in `RecordTile`.  
- 🧹 Cleaned up surrounding logic in the Education section and job descriptor code for better readability.
