### PR TITLE
ci: enhance deploy and lint workflows with modular jobs and caching

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# linted entire codebase
+746483b338ac1fb2b39207d2160332bb926bfa52

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,28 +9,57 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-24.04
+  build:
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
-          node-version: '18'
+          node-version: '22.x'
+      
+      - name: Cache node modules
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: node_modules
+          key: node_modules-${{hashFiles('package-lock.json')}}
+          restore-keys: |
+            node_modules-
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
+      
+      - name: Upload build
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: out
+          path: ./out
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+  
+    steps:
+      - name: Download build from previous job
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4.3.0
+        with:
+          name: out
+          path: ./out
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e #v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '0 4 7 1-12/2 *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint-and-check.yml
+++ b/.github/workflows/lint-and-check.yml
@@ -15,12 +15,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
-          node-version: '18'
+          node-version: '22.x'
+      
+      - name: Cache node modules
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: node_modules
+          key: node_modules-${{hashFiles('package-lock.json')}}
+          restore-keys: |
+            node_modules-
 
       - name: Install dependencies
         run: npm ci
@@ -73,12 +81,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
-          node-version: '18'
+          node-version: '22.x'
+      
+      - name: Cache node modules
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+        with:
+          path: node_modules
+          key: node_modules-${{hashFiles('package-lock.json')}}
+          restore-keys: |
+            node_modules-
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint-and-check.yml
+++ b/.github/workflows/lint-and-check.yml
@@ -3,11 +3,9 @@ name: Lint and Type-checking
 on:
   push:
     branches:
-      - main
       - dev
   pull_request:
     branches:
-      - main
       - dev
 
 jobs:


### PR DESCRIPTION
- Added `.git-blame-ignore-revs` to exclude a linting commit from git blame.
- Split `deploy.yml` into separate build and deploy jobs for modularity.
- Upgraded Node.js to 22.x and action versions in `deploy.yml` and `lint-and-check.yml`.
- Added `node_modules` caching to both workflows to reduce build times.
- Focused `lint-and-check.yml` triggers on `dev` branch and adjusted `deploy.yml` schedule to bimonthly.

---

closes #11 and closes #12 