### PR TITLE
Adjust dark mode badge styling

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -8,7 +8,8 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/Accordion';
-import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
+import BlurFade from '@/components/ui/BlurFade';
+import { BLUR_FADE_DELAY } from '@/components/ui/blurFadeConfig';
 import LinkWithArrow from '@/components/ui/LinkWithArrow';
 import StrikeHighlight from '@/components/ui/StrikeHighlighter';
 

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 
 import { EducationTile } from '@/components/Tiles/EducationTile';
-import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
+import BlurFade from '@/components/ui/BlurFade';
+import { BLUR_FADE_DELAY } from '@/components/ui/blurFadeConfig';
 
 export function Education() {
   const educationDetails = (

--- a/src/components/Experiences.tsx
+++ b/src/components/Experiences.tsx
@@ -1,4 +1,5 @@
-import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
+import BlurFade from '@/components/ui/BlurFade';
+import { BLUR_FADE_DELAY } from '@/components/ui/blurFadeConfig';
 
 import { ExperienceTileProps, ExperienceTile } from './Tiles/ExperienceTile';
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,8 @@ import { Copy, CopyCheck } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 
-import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
+import BlurFade from '@/components/ui/BlurFade';
+import { BLUR_FADE_DELAY } from '@/components/ui/blurFadeConfig';
 import LinkWithArrow from '@/components/ui/LinkWithArrow';
 
 export type HeaderProps = {

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,4 +1,5 @@
-import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
+import BlurFade from '@/components/ui/BlurFade';
+import { BLUR_FADE_DELAY } from '@/components/ui/blurFadeConfig';
 
 import { ProjectTile, ProjectTileProps } from './Tiles/ProjectTile';
 

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,7 +1,8 @@
 import { Icon } from '@iconify/react';
 
 import { Badge } from '@/components/ui/Badge';
-import BlurFade, { BLUR_FADE_DELAY } from '@/components/ui/BlurFade';
+import BlurFade from '@/components/ui/BlurFade';
+import { BLUR_FADE_DELAY } from '@/components/ui/blurFadeConfig';
 import { techIcons } from '@/lib/techIcons';
 
 interface SkillsProps {

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -9,7 +9,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          'border-transparent shadow bg-portland-peach text-chinese-black-900 hover:bg-portland-orange hover:shadow-none dark:bg-cobalt-blue dark:text-selago-200 dark:hover:bg-dark-blue',
+          'border-transparent shadow bg-portland-peach text-chinese-black-900 hover:bg-portland-orange hover:shadow-none dark:bg-white dark:text-chinese-black-950 dark:hover:bg-selago-200',
         secondary:
           'border-transparent shadow bg-chinese-black-950 text-selago-100 hover:text-chinese-black-950 hover:bg-portland-orange hover:shadow-none dark:bg-selago-200 dark:text-chinese-black-900 dark:hover:text-selago-200 dark:hover:bg-dark-blue',
         outline: 'text-chinese-black-950 dark:text-selago-100',

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -9,7 +9,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default:
-          'border-transparent shadow bg-portland-peach text-chinese-black-900 hover:bg-portland-orange hover:shadow-none dark:bg-white dark:text-chinese-black-950 dark:hover:bg-selago-200',
+          'border-transparent shadow bg-portland-peach text-chinese-black-900 hover:bg-portland-orange hover:shadow-none dark:bg-selago-100 dark:text-chinese-black-950 dark:hover:bg-selago-200 dark:hover:text-chinese-black-950',
         secondary:
           'border-transparent shadow bg-chinese-black-950 text-selago-100 hover:text-chinese-black-950 hover:bg-portland-orange hover:shadow-none dark:bg-selago-200 dark:text-chinese-black-900 dark:hover:text-selago-200 dark:hover:bg-dark-blue',
         outline: 'text-chinese-black-950 dark:text-selago-100',

--- a/src/components/ui/BlurFade.tsx
+++ b/src/components/ui/BlurFade.tsx
@@ -64,6 +64,4 @@ const BlurFade = ({
   );
 };
 
-export const BLUR_FADE_DELAY = 0.04;
-
 export default BlurFade;

--- a/src/components/ui/blurFadeConfig.ts
+++ b/src/components/ui/blurFadeConfig.ts
@@ -1,0 +1,1 @@
+export const BLUR_FADE_DELAY = 0.04;


### PR DESCRIPTION
Updates the default badge dark-mode colors from the cobalt blue treatment to a light Selago background with dark text and matching hover state. 

Moves BLUR_FADE_DELAY into a shared blurFadeConfig module so animation timing can be imported without coupling consumers to the BlurFade component export. 

## Validation: 
- `npm run build` compiles and type-checks, then fails during static export on the existing Next.js /404 prerender error: `<Html> should not be imported outside of pages/_document`; npm run lint was stopped after hanging for about two minutes with no output.